### PR TITLE
Fix for Vector Drawable use

### DIFF
--- a/app/src/main/java/aashrai/android/gettowork/di/component/ApplicationComponent.java
+++ b/app/src/main/java/aashrai/android/gettowork/di/component/ApplicationComponent.java
@@ -4,7 +4,8 @@ import aashrai.android.gettowork.di.module.ApplicationModule;
 import dagger.Component;
 import javax.inject.Singleton;
 
-@Singleton @Component(modules = ApplicationModule.class) public interface ApplicationComponent {
+@Singleton @Component(modules = ApplicationModule.class)
+public interface ApplicationComponent {
 
   SettingsComponent getSettingsComponent();
 

--- a/app/src/main/java/aashrai/android/gettowork/di/module/ApplicationModule.java
+++ b/app/src/main/java/aashrai/android/gettowork/di/module/ApplicationModule.java
@@ -2,6 +2,7 @@ package aashrai.android.gettowork.di.module;
 
 import android.content.Context;
 import android.content.SharedPreferences;
+import android.content.res.Resources;
 import android.preference.PreferenceManager;
 import dagger.Module;
 import dagger.Provides;
@@ -11,10 +12,14 @@ import javax.inject.Singleton;
 
   private final Context context;
   private final SharedPreferences sharedPreferences;
+  private final Resources resources;
+  private final Resources.Theme theme;
 
   public ApplicationModule(Context context) {
     this.context = context;
     sharedPreferences = PreferenceManager.getDefaultSharedPreferences(context);
+    this.resources = context.getResources();
+    this.theme = context.getTheme();
   }
 
   @Provides @Singleton public Context getContext() {
@@ -23,5 +28,13 @@ import javax.inject.Singleton;
 
   @Provides @Singleton public SharedPreferences getSharedPreferences() {
     return sharedPreferences;
+  }
+
+  @Provides @Singleton public Resources getResources() {
+    return resources;
+  }
+
+  @Provides @Singleton public Resources.Theme getTheme() {
+    return theme;
   }
 }

--- a/app/src/main/java/aashrai/android/gettowork/presenter/MainActivityPresenter.java
+++ b/app/src/main/java/aashrai/android/gettowork/presenter/MainActivityPresenter.java
@@ -10,9 +10,10 @@ import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.SharedPreferences;
+import android.content.res.Resources;
 import android.net.Uri;
 import android.provider.Settings;
-import android.support.v4.content.ContextCompat;
+import android.support.graphics.drawable.VectorDrawableCompat;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import javax.inject.Inject;
@@ -23,13 +24,17 @@ import javax.inject.Inject;
   private final SharedPreferences sharedPreferences;
   private final Context context;
   private MainActivityView mainActivityView;
+  private final Resources resources;
+  private final Resources.Theme theme;
 
   @Inject
   public MainActivityPresenter(Set<String> activatedPackages, SharedPreferences sharedPreferences,
-      Context context) {
+      Context context, Resources resources, Resources.Theme theme) {
     this.activatedPackages = activatedPackages;
     this.context = context;
     this.sharedPreferences = sharedPreferences;
+    this.resources = resources;
+    this.theme = theme;
   }
 
   public void setView(MainActivityView mainActivityView) {
@@ -80,7 +85,8 @@ import javax.inject.Inject;
     mainActivityView.showActivateButton();
     mainActivityView.showActivateHeader();
     mainActivityView.setActivateDrawable(
-        ContextCompat.getDrawable(context, R.drawable.ic_play_circle));
+        VectorDrawableCompat.create(resources, R.drawable.ic_play_circle, theme)
+    );
   }
 
   void storeTiming(String timing) {
@@ -116,7 +122,8 @@ import javax.inject.Inject;
 
   private void checkAndActivateAppLock() {
     mainActivityView.setActivateDrawable(
-        ContextCompat.getDrawable(context, R.drawable.ic_pause_circle));
+      VectorDrawableCompat.create(resources, R.drawable.ic_pause_circle, theme)
+    );
 
     if (activatedPackages.size() == 0) {
       mainActivityView.showToast(Constants.ADD_APPS_MESSAGE);

--- a/app/src/main/java/aashrai/android/gettowork/view/activity/MainActivity.java
+++ b/app/src/main/java/aashrai/android/gettowork/view/activity/MainActivity.java
@@ -10,10 +10,11 @@ import aashrai.android.gettowork.utils.Utils;
 import aashrai.android.gettowork.view.MainActivityView;
 import android.content.Intent;
 import android.content.SharedPreferences;
+import android.content.res.Resources;
 import android.graphics.drawable.Drawable;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
-import android.support.v4.content.ContextCompat;
+import android.support.graphics.drawable.VectorDrawableCompat;
 import android.support.v7.app.AlertDialog;
 import android.support.v7.widget.GridLayoutManager;
 import android.support.v7.widget.RecyclerView;
@@ -37,6 +38,8 @@ public class MainActivity extends BaseActivity
   @Bind(R.id.tv_pauseWarning) TextView pauseWarning;
   @Bind(R.id.tv_activateHeader) TextView activateHeader;
   MainActivityComponent mainActivityComponent;
+  @Inject Resources resources;
+  @Inject Resources.Theme theme;
 
   @Override protected void onCreate(Bundle savedInstanceState) {
     super.onCreate(savedInstanceState);
@@ -87,10 +90,9 @@ public class MainActivity extends BaseActivity
   }
 
   private void setActivateDrawable() {
-    activate.setImageDrawable(
-        Utils.isAppLockActivated(sharedPreferences) ? ContextCompat.getDrawable(this,
-            R.drawable.ic_pause_circle)
-            : ContextCompat.getDrawable(this, R.drawable.ic_play_circle));
+    activate.setImageDrawable(Utils.isAppLockActivated(sharedPreferences) ?
+            VectorDrawableCompat.create(resources, R.drawable.ic_pause_circle, theme)
+            : VectorDrawableCompat.create(resources, R.drawable.ic_play_circle, theme));
   }
 
   @Override public void configureDagger() {

--- a/app/src/main/java/aashrai/android/gettowork/view/activity/SettingsActivity.java
+++ b/app/src/main/java/aashrai/android/gettowork/view/activity/SettingsActivity.java
@@ -10,6 +10,7 @@ import aashrai.android.gettowork.view.SettingsView;
 import android.content.pm.ApplicationInfo;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
+import android.support.v4.content.ContextCompat;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
 import android.util.Log;
@@ -49,6 +50,8 @@ public class SettingsActivity extends BaseActivity
   }
 
   private void configureSearch() {
+   search.setCompoundDrawables(null, null,
+       ContextCompat.getDrawable(this, R.drawable.ic_search), null);
     search.setOnEditorActionListener(this);
     compositeSubscription = new CompositeSubscription();
     compositeSubscription.add(RxTextView.textChanges(search)

--- a/app/src/main/res/layout/activity_settings.xml
+++ b/app/src/main/res/layout/activity_settings.xml
@@ -22,7 +22,6 @@
       android:textColor="@android:color/white"
       tools:text="Facebook"
       android:theme="@style/EditTextTheme"
-      android:drawableRight="@drawable/ic_search"
       android:id="@+id/et_search"
       android:inputType="text"
       android:imeOptions="actionDone"/>


### PR DESCRIPTION
I was in a hurry to run the app and it was crashing when I was clicking Settings button or Play button. The stack trace showed this Exception in the drawable xml files.

> cause error: XmlPullParserException Binary XML file line #17<vector> tag invalid

I was so excited to see it functional on my phone that I decided to dig in and fix the bug :) 

_Why was this happening?_  

According to [this](https://plus.google.com/+AndroidDevelopers/posts/iTDmFiGrVne), AppCompat v23.2.0 doesn't have the functionality anymore which allows use of vector drawables from resources on pre-Lollipop devices. I have Android 4.3 thus getting the exception. It doesn't allow use of **drawableRight** in xml and also crashes on direct use of **getDrawable()**.

_What was the fix?_

I removed the **drawableRight** from xml and instead initialised it programmatically. Secondly, instead of **getDrawable()** I used **VectorDrawableCompat.create()** and it worked !!

Accept this PR if everything seems fine to you. Looking forward to your response. 
