### PR TITLE
Concerns addressed for usage of Vector Drawable for pre-lollipop

### DIFF
--- a/app/src/main/java/aashrai/android/gettowork/di/component/ApplicationComponent.java
+++ b/app/src/main/java/aashrai/android/gettowork/di/component/ApplicationComponent.java
@@ -4,7 +4,8 @@ import aashrai.android.gettowork.di.module.ApplicationModule;
 import dagger.Component;
 import javax.inject.Singleton;
 
-@Singleton @Component(modules = ApplicationModule.class) public interface ApplicationComponent {
+@Singleton @Component(modules = ApplicationModule.class)
+public interface ApplicationComponent {
 
   SettingsComponent getSettingsComponent();
 

--- a/app/src/main/java/aashrai/android/gettowork/di/module/ApplicationModule.java
+++ b/app/src/main/java/aashrai/android/gettowork/di/module/ApplicationModule.java
@@ -2,6 +2,7 @@ package aashrai.android.gettowork.di.module;
 
 import android.content.Context;
 import android.content.SharedPreferences;
+import android.content.res.Resources;
 import android.preference.PreferenceManager;
 import dagger.Module;
 import dagger.Provides;
@@ -11,10 +12,14 @@ import javax.inject.Singleton;
 
   private final Context context;
   private final SharedPreferences sharedPreferences;
+  private final Resources resources;
+  private final Resources.Theme theme;
 
   public ApplicationModule(Context context) {
     this.context = context;
     sharedPreferences = PreferenceManager.getDefaultSharedPreferences(context);
+    this.resources = context.getResources();
+    this.theme = context.getTheme();
   }
 
   @Provides @Singleton public Context getContext() {
@@ -23,5 +28,13 @@ import javax.inject.Singleton;
 
   @Provides @Singleton public SharedPreferences getSharedPreferences() {
     return sharedPreferences;
+  }
+
+  @Provides @Singleton public Resources getResources() {
+    return resources;
+  }
+
+  @Provides @Singleton public Resources.Theme getTheme() {
+    return theme;
   }
 }

--- a/app/src/main/java/aashrai/android/gettowork/di/module/ApplicationModule.java
+++ b/app/src/main/java/aashrai/android/gettowork/di/module/ApplicationModule.java
@@ -2,24 +2,21 @@ package aashrai.android.gettowork.di.module;
 
 import android.content.Context;
 import android.content.SharedPreferences;
-import android.content.res.Resources;
 import android.preference.PreferenceManager;
+
+import javax.inject.Singleton;
+
 import dagger.Module;
 import dagger.Provides;
-import javax.inject.Singleton;
 
 @Module public class ApplicationModule {
 
   private final Context context;
   private final SharedPreferences sharedPreferences;
-  private final Resources resources;
-  private final Resources.Theme theme;
 
   public ApplicationModule(Context context) {
     this.context = context;
     sharedPreferences = PreferenceManager.getDefaultSharedPreferences(context);
-    this.resources = context.getResources();
-    this.theme = context.getTheme();
   }
 
   @Provides @Singleton public Context getContext() {
@@ -28,13 +25,5 @@ import javax.inject.Singleton;
 
   @Provides @Singleton public SharedPreferences getSharedPreferences() {
     return sharedPreferences;
-  }
-
-  @Provides @Singleton public Resources getResources() {
-    return resources;
-  }
-
-  @Provides @Singleton public Resources.Theme getTheme() {
-    return theme;
   }
 }

--- a/app/src/main/java/aashrai/android/gettowork/presenter/MainActivityPresenter.java
+++ b/app/src/main/java/aashrai/android/gettowork/presenter/MainActivityPresenter.java
@@ -1,22 +1,23 @@
 package aashrai.android.gettowork.presenter;
 
-import aashrai.android.gettowork.utils.Constants;
-import aashrai.android.gettowork.R;
-import aashrai.android.gettowork.di.MainActivityScope;
-import aashrai.android.gettowork.utils.Utils;
-import aashrai.android.gettowork.view.MainActivityView;
-import aashrai.android.gettowork.view.activity.CreditActivity;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.SharedPreferences;
-import android.content.res.Resources;
 import android.net.Uri;
 import android.provider.Settings;
-import android.support.graphics.drawable.VectorDrawableCompat;
+
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
+
 import javax.inject.Inject;
+
+import aashrai.android.gettowork.R;
+import aashrai.android.gettowork.di.MainActivityScope;
+import aashrai.android.gettowork.utils.Constants;
+import aashrai.android.gettowork.utils.Utils;
+import aashrai.android.gettowork.view.MainActivityView;
+import aashrai.android.gettowork.view.activity.CreditActivity;
 
 @MainActivityScope public class MainActivityPresenter implements DialogInterface.OnClickListener {
 
@@ -24,17 +25,13 @@ import javax.inject.Inject;
   private final SharedPreferences sharedPreferences;
   private final Context context;
   private MainActivityView mainActivityView;
-  private final Resources resources;
-  private final Resources.Theme theme;
 
   @Inject
   public MainActivityPresenter(Set<String> activatedPackages, SharedPreferences sharedPreferences,
-      Context context, Resources resources, Resources.Theme theme) {
+      Context context) {
     this.activatedPackages = activatedPackages;
     this.context = context;
     this.sharedPreferences = sharedPreferences;
-    this.resources = resources;
-    this.theme = theme;
   }
 
   public void setView(MainActivityView mainActivityView) {
@@ -85,7 +82,7 @@ import javax.inject.Inject;
     mainActivityView.showActivateButton();
     mainActivityView.showActivateHeader();
     mainActivityView.setActivateDrawable(
-        VectorDrawableCompat.create(resources, R.drawable.ic_play_circle, theme)
+        Utils.createVectorDrawable(mainActivityView.getActivityContext(), R.drawable.ic_play_circle)
     );
   }
 
@@ -122,7 +119,7 @@ import javax.inject.Inject;
 
   private void checkAndActivateAppLock() {
     mainActivityView.setActivateDrawable(
-      VectorDrawableCompat.create(resources, R.drawable.ic_pause_circle, theme)
+        Utils.createVectorDrawable(mainActivityView.getActivityContext(), R.drawable.ic_pause_circle)
     );
 
     if (activatedPackages.size() == 0) {

--- a/app/src/main/java/aashrai/android/gettowork/presenter/MainActivityPresenter.java
+++ b/app/src/main/java/aashrai/android/gettowork/presenter/MainActivityPresenter.java
@@ -10,9 +10,10 @@ import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.SharedPreferences;
+import android.content.res.Resources;
 import android.net.Uri;
 import android.provider.Settings;
-import android.support.v4.content.ContextCompat;
+import android.support.graphics.drawable.VectorDrawableCompat;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import javax.inject.Inject;
@@ -23,13 +24,17 @@ import javax.inject.Inject;
   private final SharedPreferences sharedPreferences;
   private final Context context;
   private MainActivityView mainActivityView;
+  private final Resources resources;
+  private final Resources.Theme theme;
 
   @Inject
   public MainActivityPresenter(Set<String> activatedPackages, SharedPreferences sharedPreferences,
-      Context context) {
+      Context context, Resources resources, Resources.Theme theme) {
     this.activatedPackages = activatedPackages;
     this.context = context;
     this.sharedPreferences = sharedPreferences;
+    this.resources = resources;
+    this.theme = theme;
   }
 
   public void setView(MainActivityView mainActivityView) {
@@ -80,7 +85,8 @@ import javax.inject.Inject;
     mainActivityView.showActivateButton();
     mainActivityView.showActivateHeader();
     mainActivityView.setActivateDrawable(
-        ContextCompat.getDrawable(context, R.drawable.ic_play_circle));
+        VectorDrawableCompat.create(resources, R.drawable.ic_play_circle, theme)
+    );
   }
 
   void storeTiming(String timing) {
@@ -116,7 +122,8 @@ import javax.inject.Inject;
 
   private void checkAndActivateAppLock() {
     mainActivityView.setActivateDrawable(
-        ContextCompat.getDrawable(context, R.drawable.ic_pause_circle));
+      VectorDrawableCompat.create(resources, R.drawable.ic_pause_circle, theme)
+    );
 
     if (activatedPackages.size() == 0) {
       mainActivityView.showToast(Constants.ADD_APPS_MESSAGE);

--- a/app/src/main/java/aashrai/android/gettowork/utils/Utils.java
+++ b/app/src/main/java/aashrai/android/gettowork/utils/Utils.java
@@ -5,6 +5,8 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.content.pm.ApplicationInfo;
+import android.support.graphics.drawable.VectorDrawableCompat;
+
 import rx.functions.Func1;
 import rx.functions.Func2;
 
@@ -68,5 +70,9 @@ public class Utils {
         return (applicationInfo.flags & ApplicationInfo.FLAG_SYSTEM) == 0;
       }
     };
+  }
+
+  public static VectorDrawableCompat createVectorDrawable(final Context context, int resourceId) {
+    return VectorDrawableCompat.create(context.getResources(), resourceId, context.getTheme());
   }
 }

--- a/app/src/main/java/aashrai/android/gettowork/view/MainActivityView.java
+++ b/app/src/main/java/aashrai/android/gettowork/view/MainActivityView.java
@@ -1,5 +1,6 @@
 package aashrai.android.gettowork.view;
 
+import android.content.Context;
 import android.content.Intent;
 import android.graphics.drawable.Drawable;
 
@@ -32,4 +33,6 @@ public interface MainActivityView {
   void hideActivateButton();
 
   void showAccessibilityDialog();
+
+  Context getActivityContext();
 }

--- a/app/src/main/java/aashrai/android/gettowork/view/activity/MainActivity.java
+++ b/app/src/main/java/aashrai/android/gettowork/view/activity/MainActivity.java
@@ -10,10 +10,11 @@ import aashrai.android.gettowork.utils.Utils;
 import aashrai.android.gettowork.view.MainActivityView;
 import android.content.Intent;
 import android.content.SharedPreferences;
+import android.content.res.Resources;
 import android.graphics.drawable.Drawable;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
-import android.support.v4.content.ContextCompat;
+import android.support.graphics.drawable.VectorDrawableCompat;
 import android.support.v7.app.AlertDialog;
 import android.support.v7.widget.GridLayoutManager;
 import android.support.v7.widget.RecyclerView;
@@ -37,6 +38,8 @@ public class MainActivity extends BaseActivity
   @Bind(R.id.tv_pauseWarning) TextView pauseWarning;
   @Bind(R.id.tv_activateHeader) TextView activateHeader;
   MainActivityComponent mainActivityComponent;
+  @Inject Resources resources;
+  @Inject Resources.Theme theme;
 
   @Override protected void onCreate(Bundle savedInstanceState) {
     super.onCreate(savedInstanceState);
@@ -87,10 +90,9 @@ public class MainActivity extends BaseActivity
   }
 
   private void setActivateDrawable() {
-    activate.setImageDrawable(
-        Utils.isAppLockActivated(sharedPreferences) ? ContextCompat.getDrawable(this,
-            R.drawable.ic_pause_circle)
-            : ContextCompat.getDrawable(this, R.drawable.ic_play_circle));
+    activate.setImageDrawable(Utils.isAppLockActivated(sharedPreferences) ?
+            VectorDrawableCompat.create(resources, R.drawable.ic_pause_circle, theme)
+            : VectorDrawableCompat.create(resources, R.drawable.ic_play_circle, theme));
   }
 
   @Override public void configureDagger() {

--- a/app/src/main/java/aashrai/android/gettowork/view/activity/MainActivity.java
+++ b/app/src/main/java/aashrai/android/gettowork/view/activity/MainActivity.java
@@ -1,5 +1,24 @@
 package aashrai.android.gettowork.view.activity;
 
+import android.content.Context;
+import android.content.Intent;
+import android.content.SharedPreferences;
+import android.graphics.drawable.Drawable;
+import android.os.Bundle;
+import android.support.annotation.NonNull;
+import android.support.v7.app.AlertDialog;
+import android.support.v7.widget.GridLayoutManager;
+import android.support.v7.widget.RecyclerView;
+import android.view.View;
+import android.widget.ImageView;
+import android.widget.TextView;
+import android.widget.Toast;
+
+import java.util.Arrays;
+import java.util.List;
+
+import javax.inject.Inject;
+
 import aashrai.android.gettowork.GoToWorkApplication;
 import aashrai.android.gettowork.R;
 import aashrai.android.gettowork.adapter.TimingGridAdapter;
@@ -8,25 +27,8 @@ import aashrai.android.gettowork.presenter.MainActivityPresenter;
 import aashrai.android.gettowork.utils.TimingGridDecorator;
 import aashrai.android.gettowork.utils.Utils;
 import aashrai.android.gettowork.view.MainActivityView;
-import android.content.Intent;
-import android.content.SharedPreferences;
-import android.content.res.Resources;
-import android.graphics.drawable.Drawable;
-import android.os.Bundle;
-import android.support.annotation.NonNull;
-import android.support.graphics.drawable.VectorDrawableCompat;
-import android.support.v7.app.AlertDialog;
-import android.support.v7.widget.GridLayoutManager;
-import android.support.v7.widget.RecyclerView;
-import android.view.View;
-import android.widget.ImageView;
-import android.widget.TextView;
-import android.widget.Toast;
 import butterknife.Bind;
 import butterknife.OnClick;
-import java.util.Arrays;
-import java.util.List;
-import javax.inject.Inject;
 
 public class MainActivity extends BaseActivity
     implements MainActivityView, TimingGridAdapter.onTimingClickListener {
@@ -38,8 +40,6 @@ public class MainActivity extends BaseActivity
   @Bind(R.id.tv_pauseWarning) TextView pauseWarning;
   @Bind(R.id.tv_activateHeader) TextView activateHeader;
   MainActivityComponent mainActivityComponent;
-  @Inject Resources resources;
-  @Inject Resources.Theme theme;
 
   @Override protected void onCreate(Bundle savedInstanceState) {
     super.onCreate(savedInstanceState);
@@ -91,8 +91,8 @@ public class MainActivity extends BaseActivity
 
   private void setActivateDrawable() {
     activate.setImageDrawable(Utils.isAppLockActivated(sharedPreferences) ?
-            VectorDrawableCompat.create(resources, R.drawable.ic_pause_circle, theme)
-            : VectorDrawableCompat.create(resources, R.drawable.ic_play_circle, theme));
+            Utils.createVectorDrawable(this, R.drawable.ic_pause_circle)
+            : Utils.createVectorDrawable(this, R.drawable.ic_play_circle));
   }
 
   @Override public void configureDagger() {
@@ -186,7 +186,12 @@ public class MainActivity extends BaseActivity
         .show();
   }
 
-  @OnClick(R.id.tv_pauseWarning) public void onWarningTextClick() {
+    @Override
+    public Context getActivityContext() {
+        return this;
+    }
+
+    @OnClick(R.id.tv_pauseWarning) public void onWarningTextClick() {
     presenter.onWarningTextClick();
   }
 

--- a/app/src/main/java/aashrai/android/gettowork/view/activity/SettingsActivity.java
+++ b/app/src/main/java/aashrai/android/gettowork/view/activity/SettingsActivity.java
@@ -1,16 +1,8 @@
 package aashrai.android.gettowork.view.activity;
 
-import aashrai.android.gettowork.GoToWorkApplication;
-import aashrai.android.gettowork.R;
-import aashrai.android.gettowork.adapter.PackageListAdapter;
-import aashrai.android.gettowork.di.component.SettingsComponent;
-import aashrai.android.gettowork.presenter.SettingsActivityPresenter;
-import aashrai.android.gettowork.utils.AppListDecorator;
-import aashrai.android.gettowork.view.SettingsView;
 import android.content.pm.ApplicationInfo;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
-import android.support.v4.content.ContextCompat;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
 import android.util.Log;
@@ -21,11 +13,23 @@ import android.view.inputmethod.InputMethodManager;
 import android.widget.EditText;
 import android.widget.ProgressBar;
 import android.widget.TextView;
-import butterknife.Bind;
+
 import com.jakewharton.rxbinding.widget.RxTextView;
+
 import java.util.List;
 import java.util.concurrent.TimeUnit;
+
 import javax.inject.Inject;
+
+import aashrai.android.gettowork.GoToWorkApplication;
+import aashrai.android.gettowork.R;
+import aashrai.android.gettowork.adapter.PackageListAdapter;
+import aashrai.android.gettowork.di.component.SettingsComponent;
+import aashrai.android.gettowork.presenter.SettingsActivityPresenter;
+import aashrai.android.gettowork.utils.AppListDecorator;
+import aashrai.android.gettowork.utils.Utils;
+import aashrai.android.gettowork.view.SettingsView;
+import butterknife.Bind;
 import rx.android.schedulers.AndroidSchedulers;
 import rx.functions.Action1;
 import rx.subscriptions.CompositeSubscription;
@@ -50,8 +54,8 @@ public class SettingsActivity extends BaseActivity
   }
 
   private void configureSearch() {
-   search.setCompoundDrawables(null, null,
-       ContextCompat.getDrawable(this, R.drawable.ic_search), null);
+    search.setCompoundDrawables(null, null,
+        Utils.createVectorDrawable(this, R.drawable.ic_search), null);
     search.setOnEditorActionListener(this);
     compositeSubscription = new CompositeSubscription();
     compositeSubscription.add(RxTextView.textChanges(search)

--- a/app/src/main/java/aashrai/android/gettowork/view/activity/SettingsActivity.java
+++ b/app/src/main/java/aashrai/android/gettowork/view/activity/SettingsActivity.java
@@ -10,6 +10,7 @@ import aashrai.android.gettowork.view.SettingsView;
 import android.content.pm.ApplicationInfo;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
+import android.support.v4.content.ContextCompat;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
 import android.util.Log;
@@ -49,6 +50,8 @@ public class SettingsActivity extends BaseActivity
   }
 
   private void configureSearch() {
+   search.setCompoundDrawables(null, null,
+       ContextCompat.getDrawable(this, R.drawable.ic_search), null);
     search.setOnEditorActionListener(this);
     compositeSubscription = new CompositeSubscription();
     compositeSubscription.add(RxTextView.textChanges(search)

--- a/app/src/main/res/layout/activity_settings.xml
+++ b/app/src/main/res/layout/activity_settings.xml
@@ -22,7 +22,6 @@
       android:textColor="@android:color/white"
       tools:text="Facebook"
       android:theme="@style/EditTextTheme"
-      android:drawableRight="@drawable/ic_search"
       android:id="@+id/et_search"
       android:inputType="text"
       android:imeOptions="actionDone"/>


### PR DESCRIPTION
1) Resources and Theme removed from ApplicationModule & Injection removed
2) Activity Context added to MainActivityView Interface
3) createVectorDrawable() added to Utils and accessed from here in all instances 
